### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 install:
-  - sudo make prerequisites
+  - curl -sL https://deb.nodesource.com/setup | sudo bash -
+  - sudo apt-get update
+  - sudo apt-get install -qq xvfb chromium-browser nodejs libglapi-mesa libosmesa6 mesa-utils
+  - sudo npm install testem -g
+  - sudo pip install -r requirements.txt
+  - sudo pip install chromedriver_installer --install-option="--chromedriver-version=2.10"
 
 script:
   - export LIBGL_DEBUG=verbose; xvfb-run -s "-screen 0 1280x1024x24" glxinfo
-  - make all
-  - make unit-tests
-  - make integration-tests
+  - xvfb-run -s "-screen 0 1280x1024x24" testem -l Chromium ci --timeout 60
 
 before_script:
   - scripts/travis-checkout-data.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install:
 
 script:
   - export LIBGL_DEBUG=verbose; xvfb-run -s "-screen 0 1280x1024x24" glxinfo
-  - make
+  - make all
   - make unit-tests
   - make integration-tests
 

--- a/Makefile
+++ b/Makefile
@@ -125,10 +125,10 @@ clean-dependencies:
 	rm -rf js/libs
 
 prerequisites:
-	if ! command -v node >/dev/null 2>&1; then curl -sL https://deb.nodesource.com/setup_0.12 | bash - 2>&1; fi
+	curl -sL https://deb.nodesource.com/setup | bash - 2>&1
 	apt-get update 2>&1
-	apt-get install -y nodejs unzip openjdk-6-jre xvfb chromium-browser libglapi-mesa libosmesa6 mesa-utils python python-dev python-pip git 2>&1
-	if ! command -v testem >/dev/null 2>&1; then npm install testem -g 2>&1; fi
+	apt-get install -y nodejs unzip xvfb chromium-browser libglapi-mesa libosmesa6 mesa-utils 2>&1
+	npm install testem -g 2>&1
 	pip install -r requirements.txt 2>&1
 	pip install chromedriver_installer --install-option="--chromedriver-version=2.10" 2>&1
 

--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,8 @@ clean-dependencies:
 
 prerequisites:
 	if ! command -v node >/dev/null 2>&1; then curl -sL https://deb.nodesource.com/setup_0.12 | bash - 2>&1; fi
-	if ! command -v google-chrome >/dev/null 2>&1; then wget -q -O - "https://dl-ssl.google.com/linux/linux_signing_key.pub" | apt-key add - 2>&1; echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google-chrome.list; fi
 	apt-get update 2>&1
-	apt-get install -y nodejs unzip openjdk-6-jre xvfb chromium-browser google-chrome-stable libglapi-mesa libosmesa6 mesa-utils python python-dev python-pip git 2>&1
+	apt-get install -y nodejs unzip openjdk-6-jre xvfb chromium-browser libglapi-mesa libosmesa6 mesa-utils python python-dev python-pip git 2>&1
 	if ! command -v testem >/dev/null 2>&1; then npm install testem -g 2>&1; fi
 	pip install -r requirements.txt 2>&1
 	pip install chromedriver_installer --install-option="--chromedriver-version=2.10" 2>&1

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ prerequisites:
 clean: clean-js-build clean-dependencies
 
 unit-tests:
-	xvfb-run -s "-screen 0 1280x1024x24" testem -l Chromium ci --timeout 60
+	xvfb-run -s "-screen 0 1280x1024x24" testem -l Chromium ci --timeout 120
 
 integration-tests:
 	xvfb-run -s "-screen 0 1280x1024x24" nosetests -s -w ui_tests


### PR DESCRIPTION
This is related to https://github.com/SkyTruth/pelagos-server/issues/621, since after merging we consistently got broken builds on travis.

I removed the google chrome dependency to force integration tests to run on chrome, and increased the timeout on testem to 2 minutes instead of 1.
