### PR TITLE
Environment setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ in your machine, and no configuration is needed. For that will need:
 
 1. [Vagrant](http://www.vagrantup.com/) to manage the virtualized development
    environment. This requires installing
-[VirtualBox](https://www.virtualbox.org/) as well.
+[VirtualBox](https://www.virtualbox.org/) as well. If you are using ubuntu,
+don't install it from the standard Debian repositories, as it is an outdated
+version incompatible with our vagrantfile. Use the [official
+packages](https://www.vagrantup.com/downloads.html) instead.
 
 Once these are installed you can set up and start the virtual machine:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ Features:
 
 ## Setup
 
+The site itself does not require any specific server-side components for
+hosting; all the application is packaged as a static site and all you need to
+do to deploy it is to drop some files on an apache, nginx or any static file
+server.
+
+You do need however some development environment prerequisites to build those
+static files by downloading all library dependencies, concatenate and minify
+scripts, etc. You also need the development environment up and running if you
+want to generate test datasets, run the unit or integration tests, etc.
+
+You have 2 options to setup your development environment. You can either use
+the preferred virtualized development environment, which requires you to setup
+vagrant, or you can install all requirements in your machine.
+
 ### Quick virtualized environment
 
 You can build the application assets, run all the tests and start a development

--- a/README.md
+++ b/README.md
@@ -27,56 +27,57 @@ Features:
 
 # Development environment
 
-## Prerequisites
+## Setup
 
+### Quick virtualized environment
 
-
-## Quick virtualized environment setup
-
-You can run all the tests and development files inside a Vagrant
-virtualized machine. For that will need:
+You can build the application assets, run all the tests and start a development
+server inside a Vagrant virtualized machine. This is the preferred way of
+setting up your development environment, as no dependencies will be installed
+in your machine, and no configuration is needed. For that will need:
 
 1. [Vagrant](http://www.vagrantup.com/) to manage the virtualized development
    environment. This requires installing
-[VirtualBox](https://www.virtualbox.org/).
-
-1. A vagrant box image that you add with `vagrant box add ubuntu/precise64 http://download.appscale.com/download/AppScale%201.12.0%20VirtualBox%20Image`
+[VirtualBox](https://www.virtualbox.org/) as well.
 
 Once these are installed you can set up and start the virtual machine:
 
 1. Start the virtualized environment with `vagrant up`. This **will** take a
    while, as the entire development environment is downloaded and configured.
 
-1. SSH into the virtual machine with `vagrant ssh`, jump to the project folder
-   at `/vagrant`. You can run any of the project tasks which are run through
-   make in this directory.
+1. SSH into the virtual machine with `vagrant ssh` and jump to the project
+   folder with `cd /vagrant`.
 
-## Non-virtualized setup (on ubuntu)
+Any of the tasks described here, such as `make dev-sever` or `make all` are
+meant to be run inside the virtual machine at the `/vagrant` directory.
 
-To run all the tests etc natively
+### Non-virtualized setup (on ubuntu)
 
-1. `sudo make prerequisites`
-
-This will install all the prerequisites globally on you machine.
+If you want to instead run everything on your local machine, you will need to
+install a couple of libraries and other prerequisites.  You can do that by
+running `sudo make prerequisites`. Take a look at the makefile in this project
+to see exactly what is installed and how before running this task though.
 
 ## Running the application
 
 You can start a local development server for the application with `make
-dev-server`. The server running inside the virtualized environment is exposed
-through ssh tunneling as port 8000 in your host machine, so you can access the
+dev-server`. Remember to run the command inside the ssh session if you are
+using the virtualized environment. Once the server is up, You can access the
 application through
 `http://localhost:8000/index.html?workspace=/path/to/workspace`.
 
-Where `/path/to/workspace` is an URL to a JSON file containing a workspace
+`/path/to/workspace` is an URL to a JSON file containing a workspace
 definition. For more information about this check out [the workspace
 schema](https://github.com/SkyTruth/pelagos-client/blob/master/docs/schema.md)
 
-Example data is available in the data branch of this repo. A test workspace is
-also generated automatically by the `make dev-server` task.
+Example data is available in the `data` branch of this repo. A test workspace
+is also generated automatically by the `make dev-server` task, check out the
+output from the task, as it prints the exact url where this test workspace is
+available.
 
-## Data generation
-
-Data can be generated using the Python library https://github.com/SkyTruth/vectortile
+Data can also be generated using the
+[vectortile](https://github.com/SkyTruth/vectortile) Python library if you want
+to build your own custom workspace.
 
 # Build system
 


### PR DESCRIPTION
Expands the environment setup documentation at README.

The idea here is to make it clear that the default, easier way to get everything running is thorough vagrant. I also removed the `vagrant box` command, as it is not actually needed (vagrant up will automatically download the appropriate box).
