### PR TITLE
#455 - Adds logic to manually release sources once animations are destroyed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,10 +8,5 @@ Vagrant.configure("2") do |config|
 
   # Provision the development environment
   config.vm.provision :shell, privileged: true, inline: "cd /vagrant; make prerequisites"
-
-  # Add more virtual memory
-  config.vm.provider "virtualbox" do |v|
-    v.memory = 1024
-  end
 end
 

--- a/js/app/Data/DataManager.js
+++ b/js/app/Data/DataManager.js
@@ -91,6 +91,13 @@ define(["app/Class", "app/Bounds", "lodash", "app/Events", "app/Data/Format", "a
       ));
     },
 
+    destroyView: function(view, sourceSpec) {
+      var self = this;
+      if (view.source && sourceSpec) {
+        self.removeSource(sourceSpec)
+      }
+    },
+
     zoomTo: function (bounds) {
       var self = this;
       if (bounds.length > 0) bounds = new Bounds(bounds);

--- a/js/app/Visualization/Animation/Animation.js
+++ b/js/app/Visualization/Animation/Animation.js
@@ -69,6 +69,10 @@ define(["app/Class", "async", "app/Visualization/Animation/Shader", "app/Data/Ge
         }
       }
       self.programs = {};
+
+      if (self.data_view) {
+        self.manager.visualization.data.destroyView(self.data_view, self.source);
+      }
     },
 
     initGl: function(cb) {


### PR DESCRIPTION
Fixes https://github.com/SkyTruth/Benthos/issues/455

We have an issue where sources are added on selection (when a selection
animation is created) but they are never released (when destroying the
selection animation, for instance). Because of this, the sources begin
accumulating on each selection and increase the number of requests when
zooming in or moving the map, as all tiled sources need to be udpated
with the new bounding box.

This commit adds a destroyView method which releases all resources
created when a DataView is created inside the DataManager. Currently,
the only resources that are released are the data sources that are
registered when creating the DataView.
