### PR TITLE
Use our own version of CartoDB.js to get around cursor bug

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,6 +36,6 @@
     "stats.js": "r14",
     "font-awesome": "~4.4.0",
     "easyXDM": "~2.4.17",
-    "cartodb.js": "~3.15.8"
+    "cartodb.js": "https://github.com/SkyTruth/cartodb.js-bower.git#3.15.8-skytruth-1"
   }
 }


### PR DESCRIPTION
Connects https://github.com/SkyTruth/pelagos-server/issues/793
Connects https://github.com/SkyTruth/pelagos-server/issues/859
