### PR TITLE
#802 -  Custom CartoDB infowindows

### DIFF
--- a/js/app/Visualization/Animation/AnimationManager.js
+++ b/js/app/Visualization/Animation/AnimationManager.js
@@ -340,11 +340,11 @@ function(Class,
 
       if (rowidx) {
         var animation = self.animations[rowidx[0]];
-        if (animation.data_view) {
+        if (animation && animation.data_view) {
           animation.data_view.selections.selections[type].rawInfo = KeyModifiers.active.Shift;
         }
 
-        if (animation.select([rowidx[1], rowidx[2]], type, true, e)) {
+        if (animation && animation.select([rowidx[1], rowidx[2]], type, true, e)) {
           return animation;
         }
       } else {

--- a/js/app/Visualization/Animation/CartoDBAnimation.js
+++ b/js/app/Visualization/Animation/CartoDBAnimation.js
@@ -86,7 +86,9 @@ define([
       LoadingInfo.main.add(url, true);
 
       self.sql.execute(
-        (  self.layer.getSubLayer(layerIndex).getSQL()
+        (  'select * from ('
+         +   self.layer.getSubLayer(layerIndex).getSQL()
+         + ') as a'
          + ' where '
          + Object.keys(data).map(function (key) {
              return key + ' = {{' + key + '}}';

--- a/js/app/Visualization/Animation/CartoDBAnimation.js
+++ b/js/app/Visualization/Animation/CartoDBAnimation.js
@@ -4,6 +4,7 @@ define([
   "app/LoadingInfo",
   "app/Visualization/Animation/ObjectToTable",
   "app/Visualization/Animation/Animation",
+  "app/Visualization/UI/CartoDBInfoWindow",
   "cartodb"
 ], function(
   require,
@@ -11,6 +12,7 @@ define([
   LoadingInfo,
   ObjectToTable,
   Animation,
+  CartoDBInfoWindow,
   cartodb
 ) {
   var CartoDBAnimation = Class(Animation, {
@@ -66,54 +68,6 @@ define([
       });
     },
 
-    getInfoWindow: function (cartodb_id, cb) {
-      /* This code mimics what cdb.geo.ui.Infowindow:render() in
-       * geo/ui/infowindow.js in CartoDB.JS but without creating a
-       * whole info window popup. The API does not have a separate
-       * call for this, unfourtunately. Note: This function does NOT
-       * do any of the field value sanitation that
-       * cdb.geo.ui.Infowindow:render does because copying that much
-       * code is too ugly, and you can't call that code without
-       * creating a full info window instance. */
-      var self = this;
-      var infoWindowData = self.layer.getInfowindowData(0);
-
-      self.layer.fetchAttributes(0, cartodb_id, infoWindowData.fields, function(attributes) {
-        var model = new cdb.geo.ui.InfowindowModel(infoWindowData);
-        model.updateContent(attributes);
-
-        var fields = _.map(model.attributes.content.fields, function(field){
-          return _.clone(field);
-        });
-        var data = model.get('content') ? model.get('content').data : {};
-
-        if (model.get('template_name')) {
-          var template_name = _.clone(model.attributes.template_name);
-        }
-
-        var values = {};
-        _.each(model.get('content').fields, function(pair) {
-          values[pair.title] = pair.value;
-        })
-
-        var obj = _.extend({
-          content: {
-            fields: fields,
-            data: data
-          }
-        }, values);
-
-        var popupHtml = new cdb.core.Template({
-          template: model.get('template'),
-          type: model.get('template_type') || 'mustache'
-        }).asFunction()(
-         obj
-        )
-
-        cb($(popupHtml).find('.cartodb-popup-content'));
-      });
-    },
-
     handleMouseOver: function (event, latlng, pos, data, layerIndex) {
       var self = this;
       self.mouseOver = arguments;
@@ -131,11 +85,25 @@ define([
       if (type == 'selected') {
         self.manager.events.triggerEvent('info-loading', {});
       }
+
       var url = "CartoDB://" + self.source.args.url + "?" + JSON.stringify(data);
+
       LoadingInfo.main.add(url, true);
-      self.getInfoWindow(data.cartodb_id, function (html) {
+
+      new CartoDBInfoWindow(data.cartodb_id, self.layer).fetch(function(html) {
         LoadingInfo.main.remove(url);
-        self.manager.handleInfo(self, type, undefined, {html: html, toString: function () { return this.html; }}, {latitude: latlng[0], longitude: latlng[1]});
+
+        var data = {
+          html: html,
+          toString: function () { return this.html; }
+        };
+
+        var selectionData = {
+          latitude: latlng[0],
+          longitude: latlng[1]
+        };
+
+        self.manager.handleInfo(self, type, undefined, data, selectionData);
       });
     },
 

--- a/js/app/Visualization/Animation/ObjectToTable.js
+++ b/js/app/Visualization/Animation/ObjectToTable.js
@@ -11,7 +11,19 @@ define(["app/Class"], function(Class) {
          value = new Date(value).toISOString().replace("T", " ").split("Z")[0];
        }
        if (typeof(value)=="string" && value.indexOf("://") != -1) {
-         content.push("<tr><th colspan='2'><a target='_new' href='" + value +  "'>" + key + "</a></th></tr>");
+         var nameUrl = value.split("://")
+         var name = 'Link';
+         var url = value;
+         if (nameUrl[0].indexOf(' ') != -1) {
+           var pos = nameUrl[0].lastIndexOf(' ');
+           var proto = nameUrl[0].slice(pos + 1);
+           name = nameUrl[0].slice(0, pos);
+           if (name.slice(-1) == ':') {
+             name = name.slice(0, -1);
+           }
+           url = proto + '://' + nameUrl[1];
+         }
+         content.push("<tr><th>" + key + "</th><td><a target='_new' href='" + url +  "'>" + name + "</a></th></tr>");
        } else {
          content.push("<tr><th>" + key + "</th><td>" + value + "</td></tr>");
        }

--- a/js/app/Visualization/UI/CartoDBInfoWindow.js
+++ b/js/app/Visualization/UI/CartoDBInfoWindow.js
@@ -1,0 +1,86 @@
+define([
+  "app/Class",
+  "cartodb"
+], function(
+  Class,
+  cartodb
+) {
+  return Class({
+    name: "CartoDBInfoWindow",
+
+    initialize: function(cartodbId, cartodbLayer) {
+      this.id = cartodbId;
+      this.layer = cartodbLayer;
+    },
+
+    _fieldStringifier: function(model) {
+      return function(field) {
+        var result = _.clone(field);
+        // Check null or undefined :| and set both to empty == ''
+        if (field.value == null || field.value == undefined) {
+          result.value = '';
+        }
+
+        //Get the alternative title
+        var actualTitle = model.getAlternativeName(field.title);
+
+        if (field.title && actualTitle) {
+          result.title = actualTitle;
+        } else if (attr.title) {
+          // Remove '_' character from titles
+          result.title = field.title.replace(/_/g,' ');
+        }
+
+        // Cast all values to string due to problems with Mustache 0 number rendering
+        result.value = result.value.toString();
+
+        return result;
+      }
+    },
+
+    fetch: function(cb) {
+      var self = this;
+
+      var infoWindowData = self.layer.getInfowindowData(0);
+      if (!infoWindowData) {
+        // TODO: Push error into callback
+        return;
+      }
+
+      self.layer.fetchAttributes(0, self.id, infoWindowData.fields, function(attributes) {
+        var model = new cdb.geo.ui.InfowindowModel(infoWindowData);
+        model.updateContent(attributes);
+
+        var fields = _.map(model.attributes.content.fields, self._fieldStringifier(model));
+
+        var data = model.get('content') ? model.get('content').data : {};
+
+        if (model.get('template_name')) {
+          var template_name = _.clone(model.attributes.template_name);
+        }
+
+        var values = {};
+        _.each(model.get('content').fields, function(pair) {
+          values[pair.title] = pair.value;
+        })
+
+        var obj = _.extend({
+          content: {
+            fields: fields,
+            data: data
+          }
+        }, values);
+
+        var popupHtml = new cdb.core.Template({
+          template: model.get('template'),
+          type: model.get('template_type') || 'mustache'
+        }).asFunction()(
+         obj
+        );
+
+        cb($(popupHtml).find('.cartodb-popup-content'));
+      });
+    }
+  });
+});
+

--- a/style.less
+++ b/style.less
@@ -532,7 +532,7 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
 
     .action_icons {
       float: right;
-      margin-top: 0.7em;
+      margin-top: 0.2em;
 
       #activate_search {
         float: right;

--- a/style.less
+++ b/style.less
@@ -569,15 +569,24 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
     }
 
     #layers, #vessel_identifiers {
-      padding-left: 5%;
+      padding: 0 5%;
       word-wrap: break-word;
     }
 
     #layers h2, #vessel_identifiers h2 {
-      color: #3a3a3c;
+      color: #767777;
+      border-bottom: solid 1px #767777;
       font-size: 100%;
-      padding-top: 1rem; 
-      font-weight: 400;
+      padding-top: 0.5rem;
+      font-weight: 500;
+    }
+
+    #vessel_identifiers .cartodb-popup-content h4 {
+      margin: 0 0 0 0;
+    }
+
+    #vessel_identifiers .cartodb-popup-content p {
+      margin: 0 0 1rem 0;
     }
 
     /* toggle styles */
@@ -786,13 +795,6 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
       + .switch-line:after {
         border-color: #757575;
       }
-    }
-
-
-
-    #layers h2,
-    #vessel_identifiers h2 {
-      color: #767777; 
     }
 
     .vessel_id {


### PR DESCRIPTION
Connect https://github.com/SkyTruth/pelagos-server/issues/802.

Related to the original implementation from @redhog available at https://github.com/SkyTruth/pelagos-client/pull/107 which was closed because we are postponing this for 0.13.

In addition to @redhog changes, I extracted the original implmentation of the CartoDB infowinow to its own file, implemented a more robust infowindow routine which supports missing infowindow configurations and field renaming, and also adjusted the styles for a more compact and clear view.

I also fixed a small annoying bug which may appear if you move your mouse on top of the map before the animations are loaded (for example, while waiting for the workspace to be fetched).
