### PR TITLE
#802 - Fixes broken info windows

### DIFF
--- a/js/app/Data/CartoDBInfoWindow.js
+++ b/js/app/Data/CartoDBInfoWindow.js
@@ -26,7 +26,7 @@ define([
 
         if (field.title && actualTitle) {
           result.title = actualTitle;
-        } else if (attr.title) {
+        } else if (field.title) {
           // Remove '_' character from titles
           result.title = field.title.replace(/_/g,' ');
         }


### PR DESCRIPTION
Connects https://github.com/SkyTruth/pelagos-server/issues/802.

When an infowindow field doesn't have a custom label, there was an
error which prevented the infowindow to be displayed. This was caused
by a rename refactor gone wrong on the attribute renaming logic.
