### PR TITLE
#929 - Makes sidebar header line lighter

### DIFF
--- a/style.less
+++ b/style.less
@@ -576,7 +576,7 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
 
     #layers h2, #vessel_identifiers h2 {
       color: #767777;
-      border-bottom: solid 1px #767777;
+      border-bottom: solid 1px #ddd;
       font-size: 100%;
       padding-top: 0.5rem;
       font-weight: 500;


### PR DESCRIPTION
Connects https://github.com/SkyTruth/pelagos-server/issues/929

Makes the sidebar header title separator line lighter.
