### PR TITLE
HOTFIX 944 - Google logo hidden

### DIFF
--- a/style.less
+++ b/style.less
@@ -86,7 +86,7 @@ body {
   position: absolute;
   left: 108px;
   right: 8px;
-  bottom: 30pt;
+  bottom: 28pt;
   height: 75pt;
 }
 

--- a/style.less
+++ b/style.less
@@ -86,7 +86,7 @@ body {
   position: absolute;
   left: 108px;
   right: 8px;
-  bottom: 10pt;
+  bottom: 30pt;
   height: 75pt;
 }
 
@@ -296,7 +296,7 @@ body {
   padding-left: 7.666pt;*/
 
   position: absolute;
-  bottom: 8pt;
+  bottom: 28pt;
   /*left: 2.333pt;*/
   z-index: 5;
 
@@ -422,7 +422,7 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
   min-width: 225px;
   max-width: 551px;
   height: 100%;
-  padding-bottom: 115pt;
+  padding-bottom: 135pt;
   z-index: 10000;
 
   &.expanded {


### PR DESCRIPTION
Connects SkyTruth/pelagos-server#944

Backports this fix to 0.13 to deploy this as a hotfix before tomorrow's demo. Cherry picked https://github.com/SkyTruth/pelagos-client/commit/27bb0a52219ca289382b26bd4ece95ba580ec779, and applied a 2pt correction as discussed on slack for better spacing.
