### PR TITLE
Change the Stripe color on the search results

### DIFF
--- a/style.less
+++ b/style.less
@@ -325,7 +325,7 @@ body {
       border-spacing: 0;
       tbody {
         tr:nth-child(odd) {
-          background-color: #ccc;
+          background-color: #F7F7F7;
         }
         tr {
           .imo, .mmsi, .callsign {
@@ -342,7 +342,7 @@ body {
             }
           }
           &:hover {
-            background-color: #d2cece;
+            background-color: #F5F5F5;
           }
         }
       }


### PR DESCRIPTION
Closes SkyTruth/pelagos-server#1015 
Uses standar and softer tones of gray on the search results.
