### PR TITLE
1062 - Adds info buttons to layer list

### DIFF
--- a/js/app/Visualization/UI/SidePanels/SimpleLayerList.js
+++ b/js/app/Visualization/UI/SidePanels/SimpleLayerList.js
@@ -51,11 +51,14 @@ define([
       '    <div class="switch-line" for="cmn-toggle-${idCounter}" data-dojo-attach-point="switchNode"></div>' +
       '  </label>' +
       '  <div class="layer-label">' +
-          '<span data-dojo-attach-point="labelNode"></span>' +
-          '<div class="intensity-slider-box" data-dojo-attach-point="intensityNode">' +
-            '<div class="intensity-label">Intensity:</div>' +
-          '</div>' +
-        '</div>' +
+      '    <span data-dojo-attach-point="labelNode"></span>' +
+      '    <div class="intensity-slider-box" data-dojo-attach-point="intensityNode">' +
+      '      <div class="intensity-label">Intensity:</div>' +
+      '    </div>' +
+      '  </div>' +
+      '  <div class="layer-buttons" data-dojo-attach-point="infoNodeContainer">' +
+      '    <a target="_blank" data-dojo-attach-point="infoNode"><i class="fa fa-info"></i></a>' +
+      '  </div>' +
       '</div>',
 
     toggle: function () {
@@ -119,7 +122,7 @@ define([
 
     updatedHandler: function () {
       var self = this;
-      var title = self.animation.title
+      var title = self.animation.title;
       if (!title) title = self.animation.toString();
       $(self.labelNode).html(title);
 
@@ -131,6 +134,14 @@ define([
         $(self.inputNode).attr('checked','checked');
       } else {
         $(self.inputNode).removeAttr('checked');
+      }
+
+      var descriptionUrl = self.animation.descriptionUrl;
+      if (descriptionUrl) {
+        $(self.infoNodeContainer).show();
+        $(self.infoNode).attr("href", descriptionUrl);
+      } else {
+        $(self.infoNodeContainer).hide();
       }
     }
   });

--- a/style.less
+++ b/style.less
@@ -795,7 +795,6 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
           .layer-label,
           .switch {
             display: table-cell;
-            vertical-align: middle;
             padding-top: 10px;
             vertical-align: top;
           }
@@ -806,6 +805,7 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
           }
 
           .layer-label {
+            display: table-cell;
             color: #6D6E70;
             font-size: 90%;
             padding: 2%;
@@ -813,6 +813,12 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
             .intensity-slider-box .intensity-label {
               font-size: 0.8em;
             }
+          }
+
+          .layer-buttons {
+            display: table-cell;
+            vertical-align: top;
+            padding-top: 2px;
           }
         }
       }


### PR DESCRIPTION
Connects https://github.com/SkyTruth/pelagos-server/issues/1062.

The simple layer list used in the normal user sidebar now includes a
small link to a page with additional information about the layer.

The url for that is stored in the workspace for each animation. This has
the problem that workspaces will need to be updated when a value changes
for these kinds of things, but it's the best we can do right now as we
have already discussed we need somewhere to put layer metadata and the
changes needed for that exceed this ticket.

Some screenshot on how this looks like. The button is hidden when the layer doesn't have information:

![info-buttons-large](https://cloud.githubusercontent.com/assets/1887812/14746518/6b43e1bc-0886-11e6-96ca-460d6d737ac5.png)
