### PR TITLE
Hide filters based on workspace flag

### DIFF
--- a/js/app/Visualization/UI/BasicSidebar.js
+++ b/js/app/Visualization/UI/BasicSidebar.js
@@ -117,6 +117,12 @@ define([
       
       self.node.find("#feedback_url").attr("href", data.feedback_url);
 
+      if (data.filters_tab === false) {
+        self.sidebarContainer.removeChild(self.filters);
+      } else {
+        self.sidebarContainer.addChild(self.filters);
+      }
+
       cb && cb();
     }
   });


### PR DESCRIPTION
Connects https://github.com/SkyTruth/pelagos-server/issues/1108

To turn off the filters tab, add the following to the workspace:

```
"ui": {
    "sideBar": {
        "filters_tab": false
    }
}
```
