### PR TITLE
Bugfix for the sidebar being on top of date/time pickers and dialogs

### DIFF
--- a/js/app/Visualization/UI/style.less
+++ b/js/app/Visualization/UI/style.less
@@ -626,7 +626,7 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
   max-width: 551px;
   height: 100%;
   padding-bottom: 135pt;
-  z-index: 10000;
+  z-index: 1;
 
   &.expanded {
     #expand-button {


### PR DESCRIPTION
The sidebar has a z-index that puts it on top of dialogs and date/time picker popups. This PR fixes that.
