### PR TITLE
Remove withCredentials for the search API 

### DIFF
--- a/js/app/Data/BaseTiledFormat.js
+++ b/js/app/Data/BaseTiledFormat.js
@@ -268,7 +268,6 @@ define([
 
       var request = new XMLHttpRequest();
       request.open('GET', url, true);
-      request.withCredentials = true;
       Ajax.setHeaders(request, self.headers);
       LoadingInfo.main.add(url, {request: request});
       request.onreadystatechange = function() {


### PR DESCRIPTION
This PR is just to make a partial fix on the on going changes for beta2, the proper change will be introduced when we discuss the use of the new API.

Connects SkyTruth/pelagos-server#1118
To be discussed on: https://github.com/GlobalFishingWatch/pelagos-api/issues/48
