### PR TITLE
Roll back logo hide hack.

### DIFF
--- a/js/app/Visualization/UI/SidePanels/SidePanelManager.js
+++ b/js/app/Visualization/UI/SidePanels/SidePanelManager.js
@@ -203,18 +203,26 @@ define([
       var data = new ObjectTemplate(self.config).eval(Paths);
 
       self.node.find(".sponsor_logos").html("");
-      data.sponsorLogos.map(function (spec) {
-        if (typeof(spec) == "string") {
-          self.node.find(".sponsor_logos").append(spec);
-        } else {
-          var logo = $("<img>");
-          logo.attr(spec.attr);
-          logo.css(spec.css);
-          self.node.find(".sponsor_logos").append(logo);
-        }
-      });
+      if (data.sponsorLogos.length) {
+        data.sponsorLogos.map(function (spec) {
+          if (typeof(spec) == "string") {
+            self.node.find(".sponsor_logos").append(spec);
+          } else {
+            var logo = $("<img>");
+            logo.attr(spec.attr);
+            logo.css(spec.css);
+            self.node.find(".sponsor_logos").append(logo);
+          }
+        });
+        self.node.find(".sidebar-content").addClass("has-sponsor-logos");
+      } else {
+        self.node.find(".sidebar-content").removeClass("has-sponsor-logos");
+      }
       
-      self.node.find("#feedback_url").attr("href", data.feedback_url);
+      self.node.find("#feedback_url").toggle(!!data.feedback_url);
+      if (data.feedback_url) {
+        self.node.find("#feedback_url").attr("href", data.feedback_url);
+      }
 
       data.filters_tab = !!data.filters_tab;
       self.setTabs();

--- a/js/app/Visualization/UI/UIManager.js
+++ b/js/app/Visualization/UI/UIManager.js
@@ -566,13 +566,18 @@ define([
       self.config = config;
       data = new ObjectTemplate(self.config).eval(Paths);
 
-      if (typeof(data.logo) == "string") {
-        self.logoNode.append(data.logo);
+      if (data.logo) {
+        self.logoNode.show();
+        if (typeof(data.logo) == "string") {
+          self.logoNode.append(data.logo);
+        } else {
+          var logo = $("<img>");
+          logo.attr(data.logo.attr);
+          logo.css(data.logo.css);
+          self.logoNode.append(logo);
+        }
       } else {
-        var logo = $("<img>");
-        logo.attr(data.logo.attr);
-        logo.css(data.logo.css);
-        self.logoNode.append(logo);
+        self.logoNode.hide();
       }
 
       self.sideBar.load(config.sideBar, cb);

--- a/js/app/Visualization/UI/style.less
+++ b/js/app/Visualization/UI/style.less
@@ -101,7 +101,7 @@ body {
 
 .logo {
   position: absolute;
-  left: 40pt;
+  left: 8pt;
   top: 10pt;
   pointer-events: none;
 }
@@ -566,7 +566,7 @@ content: "\f067";
 
 /* hide Google, CartoDB logos */
 
-.cartodb-logo, #cartodb-gmaps-attribution, .logo img, .gmnoprint a, .gmnoprint span  {
+.cartodb-logo, #cartodb-gmaps-attribution, .gmnoprint a, .gmnoprint span  {
     visibility: hidden;
     display: none;
     width: 0;
@@ -771,6 +771,7 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
         cursor: default;
       }
       .header {
+        height: 23px;
         #activate_help{
           font-size: 15pt;
           float: right;
@@ -787,7 +788,7 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
 
       .blades {
         height: 100%;
-        padding-bottom: 25pt;
+        padding-bottom: 23pt;
         .basic-sidebar {
           height: 100%;
           width: 100%;
@@ -795,6 +796,17 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
       }
       .sponsor_logos {
         display: none;
+      }
+
+      &.has-sponsor-logos {
+        .sponsor_logos {
+          height: 23pt;
+          margin-top: -46pt;
+          display: block;
+        }
+        .blades {
+          padding-bottom: 46pt;
+        }
       }
     }
 


### PR DESCRIPTION
Connects https://github.com/SkyTruth/pelagos-server/issues/1130

Note: To not show any logos, use the following config.json:

```
{
  "ui": {
    "logo": null,
    "sideBar": {
      "feedback_url": null,
      "sponsorLogos": []
    }
  }
}
```
