### PR TITLE
Support for hiding key combinations from help

### DIFF
--- a/js/app/Visualization/KeyBindings.js
+++ b/js/app/Visualization/KeyBindings.js
@@ -14,16 +14,33 @@ define([
   KeyBindings.byCategory = {};
   KeyBindings.byKeys = {};
 
-  KeyBindings.keysToKeyPath = function (keys) {
-    return keys.sort().join('-');
-  };
-
-  KeyBindings.register = function (keys, context, category, description, cb) {
-    keys = keys.slice();
-    var keyPath = KeyBindings.keysToKeyPath(keys);
+  KeyBindings.keysToKeyPath = function (keys, context) {
+    var keyPath = keys.sort().join('-');
     if (context) {
       keyPath = keyPath + " " + context;
     }
+    return keyPath;
+  };
+
+  KeyBindings.hide = function (keys, context) {
+    var keyPath = KeyBindings.keysToKeyPath(keys, context);
+    if (KeyBindings.byKeys[keyPath]) KeyBindings.byKeys[keyPath].visible = false;
+  },
+
+  KeyBindings.show = function (keys, context) {
+    if (!keys) {
+      for (var keyPath in KeyBindings.byKeys) {
+        KeyBindings.byKeys[keyPath].visible = true;
+      }
+    } else {
+      var keyPath = KeyBindings.keysToKeyPath(keys, context);
+      if (KeyBindings.byKeys[keyPath]) KeyBindings.byKeys[keyPath].visible = true;
+    }
+  },
+
+  KeyBindings.register = function (keys, context, category, description, cb) {
+    keys = keys.slice();
+    var keyPath = KeyBindings.keysToKeyPath(keys, context);
 
     var registration = {
       keys: keys,
@@ -31,6 +48,7 @@ define([
       keyPath: keyPath,
       category: category,
       description: description,
+      visible: true,
       cb: cb
     };
 
@@ -50,6 +68,7 @@ define([
       var bindings = KeyBindings.byCategory[category];
       Object.keys(bindings).map(function (keyPath) {
         var registration = bindings[keyPath];
+        if (!registration.visible) return;
         var regHtml = $("<div class='binding'><a href='javascript: void(0);'><div class='key-codes'></div><div class='description'></div></a></div>");
         regHtml.find("a").click(function () {
           if (registration && registration.cb) {

--- a/js/app/Visualization/UI/UIManager.js
+++ b/js/app/Visualization/UI/UIManager.js
@@ -575,6 +575,13 @@ define([
         self.logoNode.append(logo);
       }
 
+      KeyBindings.show();
+      if (config.hideKeys) {
+        config.hideKeys.map(function (key) {
+          KeyBindings.hide(key.keys, key.context);
+        });
+      }
+
       self.sideBar.load(config.sideBar, cb);
     }
   });


### PR DESCRIPTION
Connects https://github.com/SkyTruth/pelagos-server/issues/1126

To use this, place the following in config.json:

```
{
  "ui": {
    "hideKeys": [
      {"keys": ["Alt", "Ctrl", "E"]}
    ]
  }
}
```
