### PR TITLE
[DO NOT MERGE] Dynamic PointSize for cluster animation

### DIFF
--- a/js/app/Visualization/Animation/ClusterAnimation-vertex.glsl
+++ b/js/app/Visualization/Animation/ClusterAnimation-vertex.glsl
@@ -7,6 +7,8 @@ uniform float zoom;
 
 uniform mat4 googleMercator2webglMatrix;
 
+uniform float ps;
+
 varying float vWeight;
 
 float latLonDistanceToWebGL(float distance, vec2 lonlat, mat4 googleMercator2webglMatrix) {
@@ -28,8 +30,6 @@ void main() {
     gl_PointSize = 0.0;
     vWeight = 0.0;
   } else {
-    float ps = 0.01; // In WebGL units
-
     float webglSigma = latLonDistanceToWebGL(_sigma, lonlat, googleMercator2webglMatrix);
 
     float radius = ps + 2.5 * webglSigma;

--- a/js/app/Visualization/Animation/ClusterAnimation.js
+++ b/js/app/Visualization/Animation/ClusterAnimation.js
@@ -14,6 +14,10 @@ define(["require", "app/Class", "app/Visualization/Shader", "app/Visualization/A
       filter: {type: "Float32", source: {_: null, timerange: -1.0, active_category: -1.0}}
     },
 
+    uniforms: {
+      ps: {min: 0.001, max: 0.05, value: 0.01}
+    },
+
     selections: $.extend(
       {active_category: {sortcols: ["category"], max_range_count: 3, data: {category: [-1.0/0.0, 1.0/0.0]}, header: {length: 2}}},
       Animation.prototype.selections


### PR DESCRIPTION
This PR represents a feature developed long time ago and later ignored. This PR is meant to track the branch to easier see how the feature worked. Please do not delete or merge.

This PR lets the user control the base point size of clusters (with zigma 0 that is) using e.g. the editing sidebar.
