### PR TITLE
[After Release] Basic withCredentials handling not to have to retry all requests

### DIFF
--- a/js/app/Data/Ajax.js
+++ b/js/app/Data/Ajax.js
@@ -43,43 +43,53 @@ define([
     };
   };
 
-  Ajax.makeRequest = function (verb, url, headers, cb) {
+  Ajax.makeSimpleRequest = function (verb, url, headers, withCredentials, cb) {
+    /* Handle file:// urls as well as CORS correctly. */
+    var request = new XMLHttpRequest();
+    request.open(verb, url, true);
+    request.withCredentials = withCredentials;
+    Ajax.setHeaders(request, headers);
+    LoadingInfo.main.add(url, {request: request});
+    request.onreadystatechange = function() {
+      if (request.readyState === 4) {
+        LoadingInfo.main.remove(url);
+        if (Ajax.isSuccess(request, url)) {
+          cb(null, JSON.parse(request.responseText));
+        } else {
+          cb(Ajax.makeError(request, url));
+        }
+      }
+    };
+    request.send(null);
+  },
+
+  Ajax.makeRequest = function (verb, url, headers, cb, withCredentials) {
     /* Handle file:// urls as well as CORS correctly, as well as the
      * combinations of CORS and credentials and CORS, credentials and CDNs
-     * that set the CORS domain to *. */
+     * that set the CORS domain to *.
 
-    var doLoad = function (withCredentials) {
-      var request = new XMLHttpRequest();
-      request.open(verb, url, true);
-      request.withCredentials = withCredentials;
-      Ajax.setHeaders(request, headers);
-      LoadingInfo.main.add(url, {request: request});
-      request.onreadystatechange = function() {
-        if (request.readyState === 4) {
-          LoadingInfo.main.remove(url);
-          if (Ajax.isSuccess(request, url)) {
-            cb(null, JSON.parse(request.responseText));
-          } else {
-            if (withCredentials) {
-              doLoad(false);
-            } else {
-              cb(Ajax.makeError(request, url));
-            }
-          }
-        }
-      };
-      request.send(null);
-    };
-    doLoad(true);
+     * If withCredentials is undefined, the request is first tried
+     * with withCredentials = true, then if that fails with
+     * withCredentials = false.
+     */
+
+    var firstWithCredentials = withCredentials === undefined ? true : withCredentials;
+    Ajax.makeSimpleRequest(verb, url, headers, firstWithCredentials, function (err, data) {
+      if (!err || withCredentials !== undefined) return cb(err, data, firstWithCredentials);
+
+      Ajax.makeSimpleRequest(verb, url, headers, false, function (err, data) {
+        cb(err, data, false);
+      });
+    });
   };
 
   /* TODO: Implement proper body parsing and sending */
-  Ajax.post = function (url, headers, cb) {
-    Ajax.makeRequest('POST', url, headers, cb);
+  Ajax.post = function (url, headers, cb, withCredentials) {
+    Ajax.makeRequest('POST', url, headers, cb, withCredentials);
   };
 
-  Ajax.get = function (url, headers, cb) {
-    Ajax.makeRequest('GET', url, headers, cb);
+  Ajax.get = function (url, headers, cb, withCredentials) {
+    Ajax.makeRequest('GET', url, headers, cb, withCredentials);
   };
 
   return Ajax;

--- a/js/app/Data/TiledBinFormat.js
+++ b/js/app/Data/TiledBinFormat.js
@@ -22,13 +22,18 @@ define(["app/Class", "app/Data/Format", "app/Data/BaseTiledFormat", "app/Data/Bi
 
     getTileContent: function (tile) {
       var self = this;
+      var withCredentials = self.withCredentials;
+      if (self.header.tilesWithCredentials !== undefined) {
+        withCredentials = self.header.tilesWithCredentials;
+      }
+
       var base = self.getUrl(
         "tile",
         tile.bounds.toString(),
         tile.fallbackLevel);
       var content = new BinFormat({
         url: base + "/" + tile.bounds.toString(),
-        withCredentials: self.header.tilesWithCredentials
+        withCredentials: withCredentials
       });
       content.setHeaders(self.headers);
       return content;


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/pelagos-client/issues/263

Note that this PR does not reuse the withCredentials flag from a tileset on its /sub/seriesgroup=value sub tilesets, but each tileset, even sub tilesets have their header tried with and without withcredentials and this is then reused for all subsequent calls.

Also note that this does not override a tilesWithCredentials flag inside the header, which applies only to tile requests, not info and search.
