### PR TITLE
[WIP] Fix for #1142

### DIFF
--- a/js/app/Visualization/UI/style.less
+++ b/js/app/Visualization/UI/style.less
@@ -503,23 +503,14 @@ content: "\f067";
   .fa {
     color: #ffffff;
     font-size: 12pt;
-    width: 22px;
-    height: 22px;
-    text-align: center;
   }
 
   button {
-    border: hidden;
     background-color: transparent;
     border: none !important;
     margin: 0 !important;
     cursor: pointer;
-
-    img {
-        width: 15pt;
-        height: 15pt;
-
-    }
+    padding: 0;
   }
 
   button.btn:focus {


### PR DESCRIPTION
Fix for [#1142](https://github.com/SkyTruth/pelagos-server/issues/1142)

Modified icon styles so they are not cut off on some devices (e.g., iPad mini).

Unable to test on iPad, so may not be ready to merge.
