### PR TITLE
Bugfix for sidebar resize

### DIFF
--- a/js/app/Visualization/UI/SidePanels/SidePanelManager.js
+++ b/js/app/Visualization/UI/SidePanels/SidePanelManager.js
@@ -168,7 +168,11 @@ define([
 
     resizeStart: function (e) {
       var self = this;
+      var resize = self.node.find(".sidebar-content");
       var pos = self.getFirstPosition(self.getEventPositions(e));
+
+      if (pos.pageX > resize.offset().left + (resize.outerWidth() - resize.innerWidth())) return;
+
       self.resizing = {
         original_pos: pos,
         original_width: self.node.outerWidth()


### PR DESCRIPTION
The sidebar resize lets you click anywhere in the sidebar to initiate resize. This disturbs other widgets and was never intended. This PR fixes that, so that only the edge of the sidebar is dragable.
