### PR TITLE
Cluster message typo

### DIFF
--- a/js/app/Visualization/Animation/AnimationManager.js
+++ b/js/app/Visualization/Animation/AnimationManager.js
@@ -760,7 +760,7 @@ function(Class,
         var data = {
           layer: animation.title,
           toString: function () {
-            return 'There are multiple vessesls at this location. Zoom in on the map some more to see individual points.';
+            return 'There are multiple vessels at this location. Zoom in to see individual points.';
           }
         };
         self.handleSelectionInfo(animation, selectionEvent, null, data);

--- a/js/app/Visualization/UI/style.less
+++ b/js/app/Visualization/UI/style.less
@@ -876,13 +876,13 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
     th {
       text-align: left;
       vertical-align: top;
-      font-size: 80%;
+      font-size: 9pt;
       font-weight: 400;
       padding: 0;
       margin: 0;
 
       td {
-        font-size: 80%;
+        font-size: 9pt;
         font-weight: normal;
         padding: 0;
         margin: 0;
@@ -891,6 +891,15 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
           width: 20%;
         }
       }
+    }
+
+    #vessel_identifiers {
+        font-size: 9pt;
+    }
+
+    #DataQualityLevel_0 div,
+    #DataQualityLevel_0 div .value {
+        font-size: 9pt;
     }
 
     #layers, .InfoUI .wrapper {
@@ -926,9 +935,7 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
           .left-buttons,
           .animation-buttons {
             vertical-align: top;
-            padding-top: 2px;
             white-space: nowrap;
-            font-size: 90%;
 
             > * {
               padding-right: 10px;
@@ -946,11 +953,11 @@ hyperwall is: 3 1280px screens wide and 3 720pxs screens high.
 
           .animation-content {
             color: #ffffff;
-            font-size: 80%;
+            font-size: 9pt;
             width: 100%;
 
             .animation-editor {
-              font-size: 80%;
+              font-size: 9pt;
 
               .SimpleAnimationEditor {
                 > * {


### PR DESCRIPTION
Connects: https://github.com/SkyTruth/pelagos-server/issues/1182
- fix typo in cluster selected message
- adjust sidebar text styles so they are uniform
