### PR TITLE
Handle partial directory listing failures

### DIFF
--- a/js/app/Data/DataManager.js
+++ b/js/app/Data/DataManager.js
@@ -285,25 +285,22 @@ define([
         "total": 0,
         "limit": limit,
         "offset": offset,
-        "nextOffset": offset + limit
+        "nextOffset": offset + limit,
+        "errors": []
       };
 
       async.each(self.directories, function (baseUrl, cb) {
         self.queryDirectory(baseUrl, query, offset, limit, function (err, data) {
           if (err) {
-            cb(err);
+            res.errors.push(err);
           } else {
             res.entries = res.entries.concat(data.entries);
             res.total += data.total;
-            cb();
           }
+          cb();
         });
       }, function (err) {
-        if (err) {
-          cb(err);
-        } else {
-          cb(null, res);
-        }
+        cb(res);
       });
     },
 

--- a/js/app/Visualization/UI/AnimationLibrary.js
+++ b/js/app/Visualization/UI/AnimationLibrary.js
@@ -79,17 +79,26 @@ define([
       );
     },
 
-    displaySearchResults: function (err, res) {
+    displaySearchResults: function (res) {
       var self = this;
       self.currentResults = res;
       TemplatedDialog.prototype.show.call(self);
       $(self.containerNode).find('.search-loading').hide();
       var results = $(self.containerNode).find('.results');
-      if (err) {
-        results.html('<div class="error">An error occured: ' + err.toString() + '<div>');
+
+      results.html("");
+
+      if (res.errors.length > 0) {
+        var errors = $('<div class="error"><div>An error occured:</div><div>');
+        res.errors.map(function (err) {
+          errors.append(err.toString());
+        });
+        results.append(errors);
       } else if (res.total == 0) {
-        results.html('<div class="no-results">No results found</div>');
-      } else {
+        results.append('<div class="no-results">No results found</div>');
+      }
+
+      if (res.total > 0) {
         if (res.offset > 0 || res.total > res.offset + res.entries.length) {
           $(self.containerNode).find('.paging').show();
 
@@ -111,7 +120,7 @@ define([
           $(self.containerNode).find('.paging').hide();
         }
 
-        results.html('<table class="table result-table">' +
+        results.append('<table class="table result-table">' +
                      '  <tr>' +
                      '    <th class="title">Title</th>' +
                      '    <th class="description">Description</th>' +


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/pelagos-client/issues/390

When a workspace has more than one animation directory, some of those directories can fail while other succeeds. The old code would not let the user use the working ones, this PR displays both the errors and the results.
