### PR TITLE
263 - Removes the whole withCredentials handling

### DIFF
--- a/js/app/Data/Ajax.js
+++ b/js/app/Data/Ajax.js
@@ -47,30 +47,21 @@ define([
     /* Handle file:// urls as well as CORS correctly, as well as the
      * combinations of CORS and credentials and CORS, credentials and CDNs
      * that set the CORS domain to *. */
-
-    var doLoad = function (withCredentials) {
-      var request = new XMLHttpRequest();
-      request.open(verb, url, true);
-      request.withCredentials = withCredentials;
-      Ajax.setHeaders(request, headers);
-      LoadingInfo.main.add(url, {request: request});
-      request.onreadystatechange = function() {
-        if (request.readyState === 4) {
-          LoadingInfo.main.remove(url);
-          if (Ajax.isSuccess(request, url)) {
-            cb(null, JSON.parse(request.responseText));
-          } else {
-            if (withCredentials) {
-              doLoad(false);
-            } else {
-              cb(Ajax.makeError(request, url));
-            }
-          }
+    var request = new XMLHttpRequest();
+    request.open(verb, url, true);
+    Ajax.setHeaders(request, headers);
+    LoadingInfo.main.add(url, {request: request});
+    request.onreadystatechange = function() {
+      if (request.readyState === 4) {
+        LoadingInfo.main.remove(url);
+        if (Ajax.isSuccess(request, url)) {
+          cb(null, JSON.parse(request.responseText));
+        } else {
+          cb(Ajax.makeError(request, url));
         }
-      };
-      request.send(data);
+      }
     };
-    doLoad(true);
+    request.send(data);
   };
 
   Ajax.post = function (url, headers, data, cb) {

--- a/js/app/Data/BaseTiledFormat.js
+++ b/js/app/Data/BaseTiledFormat.js
@@ -216,11 +216,10 @@ define([
        query = self.getSelectionQuery(selection); 
       }
 
-      var getSelectionInfo = function (fallbackLevel, withCredentials) {
+      var getSelectionInfo = function (fallbackLevel) {
         var url = self.getQueryUrl(query, fallbackLevel) + "/info";
         var request = new XMLHttpRequest();
         request.open('GET', url, true);
-        request.withCredentials = withCredentials;
         Ajax.setHeaders(request, self.headers);
         LoadingInfo.main.add(url, {request:request});
         request.onreadystatechange = function() {
@@ -243,15 +242,13 @@ define([
                     new PopupAuth(data.auth_location, function (success) {
                       if (success) {
                         cb(null, null);
-                        getSelectionInfo(fallbackLevel, withCredentials);
+                        getSelectionInfo(fallbackLevel);
                       }
                     });
                   });
                   return res;
                 };
                 cb(data, null);
-              } else if (request.status == 0 && withCredentials) {
-                getSelectionInfo(fallbackLevel, false);
               } else if (fallbackLevel + 1 < self.getUrlFallbackLevels("selection-info")) {
                 getSelectionInfo(fallbackLevel + 1, true);
               } else {

--- a/js/app/Data/TiledBinFormat.js
+++ b/js/app/Data/TiledBinFormat.js
@@ -13,7 +13,6 @@
 define(["app/Class", "app/Data/Format", "app/Data/BaseTiledFormat", "app/Data/BinFormat"], function(Class, Format, BaseTiledFormat, BinFormat) {
   var TiledBinFormat = Class(BaseTiledFormat, {
     name: "TiledBinFormat",
-    withCredentials: false,
 
     getTileContent: function (tile) {
       var self = this;
@@ -23,7 +22,6 @@ define(["app/Class", "app/Data/Format", "app/Data/BaseTiledFormat", "app/Data/Bi
         tile.fallbackLevel);
       var content = new BinFormat({
         url: base + "/" + tile.bounds.toString(),
-        withCredentials: self.header.tilesWithCredentials
       });
       content.setHeaders(self.headers);
       return content;

--- a/js/app/Data/TypedMatrixParser.js
+++ b/js/app/Data/TypedMatrixParser.js
@@ -113,7 +113,6 @@ define([
   return Class({
     name: "TypedMatrixParser",
     MAGIC_COOKIE: 'tmtx',
-    withCredentials: false,
     initialize: function(url, args) {
       var self = this;
 
@@ -170,7 +169,6 @@ define([
 
       LoadingInfo.main.add(self.url, {request: self.request});
       self.request.open('GET', self.url, true);
-      self.request.withCredentials = self.withCredentials;
       self.request.responseType = "arraybuffer";
       for (var key in self.headers) {
         var values = self.headers[key]


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/pelagos-client/issues/263

As per the discussion on https://github.com/GlobalFishingWatch/pelagos-client/pull/282#issuecomment-244988530, I'm removing the whole `withCredentials` logic from the client. It's not really needed anywhere now that we have the new API, and the value for other users is not really justified as the `withCredentials` flag is a very rare need.

If this PR is merged, then we can close https://github.com/GlobalFishingWatch/pelagos-client/pull/282.
