### PR TITLE
Basic solution for selection on top of selection

### DIFF
--- a/js/app/Visualization/Animation/AnimationManager.js
+++ b/js/app/Visualization/Animation/AnimationManager.js
@@ -514,6 +514,9 @@ define([
 
     showSelectionAnimations: function (baseAnimation, selectionIter, autoSave, cb) {
       var self = this;
+
+      if (!cb) cb = function () {};
+
       var baseHeader = baseAnimation.data_view.source.header;
 
       if (!baseHeader.seriesTilesets) return;
@@ -526,11 +529,20 @@ define([
         selectionIter = selectionIter.iterate();
       }
 
-      var queryValues = selectionIter(true).map(function (item) {
-        return item.value.toString();
-      }).join(",");
+      var query = undefined;
+      var queryValues;
+      try {
+        while (!query) {
+          queryValues = selectionIter(true).map(function (item) {
+            return item.value.toString();
+          }).join(",");
 
-      var query = baseAnimation.data_view.source.getSelectionQuery(selectionIter);
+          query = baseAnimation.data_view.source.getSelectionQuery(selectionIter);
+        }
+      } catch (e) {
+        return cb(e);
+      }
+
       if (query.length > 0) {
         var seriesTilesets = baseAnimation.args.seriesTilesets;
 
@@ -622,7 +634,7 @@ define([
             });
             delete selection.data.zoomToSelectionAnimations;
           }
-          if (cb) cb(seriesAnimations);
+          cb(null, seriesAnimations);
         });
       }
     },


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Issues/issues/9
- When selecting something on a vessel tileset (/sub/seriesgroup=x), adding the series group again does not make sense
- If the sortcols of the selection is the same as the one in the url to the tileset, then no new tileset url can actually be constructed, and adding one more animation is senseless or showing selection info is senseless.
