### PR TITLE
11 - Makes the display animation search results work

### DIFF
--- a/js/app/Visualization/UI/AnimationLibrary.js
+++ b/js/app/Visualization/UI/AnimationLibrary.js
@@ -94,11 +94,6 @@ define([
         entries,
         function (entry, cb) {
           self.visualization.data.getSourceInfo(entry.args.source, function (err, data) {
-            if (data) {
-              data.toString = function () {
-                return ObjectToTable(this);
-              };
-            }
             cb(null, {animation: entry, error: err, info: data});
           });
         },
@@ -159,12 +154,19 @@ define([
           var row = $('<tr><td><a class="title"></a></td><td><a class="description"></a></td>');
           row.find(".title").html(entry.animation.args.title);
 
+
+
           if (entry.error) {
-            var err = $("<div class='error'></div>");
-            err.html(entry.error.toString());
-            row.find(".description").html(err);
+            if (entry.animation && entry.animation.args && entry.animation.args.description) {
+              row.find(".description").html(entry.animation.args.description);
+            } else {
+              var err = $("<div class='error'></div>");
+              err.html(entry.error.toString());
+              row.find(".description").html(err);
+            }
           } else {
-            row.find(".description").html(entry.info.toString());
+            var infoHtml = ObjectToTable(entry.info, { render_title: false });
+            row.find(".description").html(infoHtml);
           }
 
           row.find('a').click(function () {


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Issues/issues/11.

The ObjectToTable function calls toString on the object when it has this method. We were previously calling ObjectToTable in the toString method when displaying animation information, causing infinite
recursion.

We also had a problem with the bathymetry layer, which has no innate info. I'm now falling back to the workspace configuration if for whatever reason there is no info for a layer.
