### PR TITLE
Added a debugger tool for mouseover data

### DIFF
--- a/js/app/Visualization/UI/MouseoverDebugger.js
+++ b/js/app/Visualization/UI/MouseoverDebugger.js
@@ -1,0 +1,43 @@
+define([
+  "app/Class",
+  "app/Visualization/KeyBindings",
+  "shims/lodash/main",
+  "shims/jQuery/main"
+], function (
+  Class,
+  KeyBindings,
+  _,
+  $
+) {
+  return Class({
+    name: "MouseoverDebugger",
+
+    initialize: function (args) {
+      var self = this;
+      _.extend(self, args);
+      self.state = 0;
+      self.current = undefined;
+      KeyBindings.register(
+        ['Ctrl', 'Alt', 'M'], null, 'General',
+        'Show the mouseover debugger',
+        self.toggle.bind(self)
+      );
+    },
+
+    startup: function () {},
+
+    toggle: function () {
+      var self = this;
+
+      self.state = (self.state + 1) % (self.visualization.animations.rowidxGl.length + 1);
+      if (self.current) {
+        self.current.detach();
+        self.current = undefined;
+      }
+      if (self.state == 0) return;
+      self.current = $(self.visualization.animations.rowidxGl[self.state - 1].canvas);
+      $("body").append(self.current);
+      self.current.css({position: "absolute", left: 0, top: 0, right: 0, bottom: 0, "z-index": 2, "pointer-events": "none"});
+    }
+  });
+});

--- a/js/app/Visualization/UI/UIManager.js
+++ b/js/app/Visualization/UI/UIManager.js
@@ -15,6 +15,7 @@ define([
   "app/Visualization/UI/Help",
   "app/Visualization/UI/SimpleMessageDialog",
   "app/Visualization/UI/WelcomeMessageDialog",    
+  "app/Visualization/UI/MouseoverDebugger",    
   "app/Visualization/UI/ZoomButtons",
   "app/Visualization/UI/LoaderIcon",
   "app/ObjectTemplate",
@@ -43,6 +44,7 @@ define([
   Help,
   SimpleMessageDialog,
   WelcomeMessageDialog,
+  MouseoverDebugger,
   ZoomButtons,
   LoaderIcon,
   ObjectTemplate,
@@ -528,6 +530,9 @@ define([
       self.saveWorkspace.startup();
       self.help = new Help({visualization: self.visualization});
       self.help.startup();
+      self.mouseoverDebugger = new MouseoverDebugger({visualization: self.visualization});
+      self.mouseoverDebugger.startup();
+
       cb();
     },
 


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Issues/issues/20

Usage:

Press CTRL-ALT-M to toggle between the normal map, and the two mouseover canvases overlayed. The overlays only display content where it has been requested by getRowidxAtPos. The two overlay canvases represents the first and last three bytes of the rowidx.
