### PR TITLE
Change openjdk to use the version 8.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ clean: clean-js-build clean-dependencies clean-integration-tests
 prerequisites:
 	curl -sL https://deb.nodesource.com/setup_6.x | bash -
 	apt-get update
-	apt-get install -y firefox chromium-browser nodejs unzip openjdk-7-jre xvfb python python-dev python-pip git-core libglapi-mesa libosmesa6 mesa-utils
+	apt-get install -y firefox chromium-browser nodejs unzip openjdk-8-jre xvfb python python-dev python-pip git-core libglapi-mesa libosmesa6 mesa-utils
 	npm install -g testem
 	pip install --upgrade pip
 	pip install -r requirements.txt


### PR DESCRIPTION
@andres-arana I'm changing the version to openjdk8, but we need to make the vagrant box for devel work with this version. I will give it a try this afternoon. 