### PR TITLE
Normalizes selection name for the report filters

### DIFF
--- a/js/app/Visualization/UI/GenerateReportDialog.js
+++ b/js/app/Visualization/UI/GenerateReportDialog.js
@@ -124,7 +124,11 @@ define([
           })
           .value();
 
-        return [selectionName, values];
+        var normalizedSelectionName = selectionName.replace(/\s/g, '');
+        normalizedSelectionName = normalizedSelectionName
+          .charAt(0).toLowerCase() + normalizedSelectionName.substring(1);
+
+        return [normalizedSelectionName, values];
       });
 
       var result = _(values)


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/api-pelagos/issues/71

Normalizes the selection name before building the filters as the selection name is a visible label.