### PR TITLE
Re-enable the area inspector on the map

### DIFF
--- a/js/app/Visualization/Animation/AnimationManager.js
+++ b/js/app/Visualization/Animation/AnimationManager.js
@@ -759,12 +759,10 @@ define([
       var self = this;
 
       async.series([
-/*
         function (cb) {
           self.bboxSelection = new BboxSelection(self, {});
           self.addAnimationInstance(self.bboxSelection, cb, "overlays");
         }
-*/
       ], cb);
     },
 


### PR DESCRIPTION
Revert "Disable BboxSelection. revert this commit to reenable the area inspector"
This reverts commit 7deb941e3bad01f6db8a8304f6911b7cb2352905.